### PR TITLE
Using HTTP_HOST as default installation URL

### DIFF
--- a/user/config-sample.php
+++ b/user/config-sample.php
@@ -32,7 +32,7 @@ define( 'YOURLS_DB_PREFIX', 'yourls_' );
 
 /** YOURLS installation URL -- all lowercase and with no trailing slash.
  ** If you define it to "http://sho.rt", don't use "http://www.sho.rt" in your browser (and vice-versa) */
-define( 'YOURLS_SITE', 'http://your-own-domain-here.com' );
+define( 'YOURLS_SITE', 'http://' . $_SERVER["HTTP_HOST"] );
 
 /** Server timezone GMT offset */
 define( 'YOURLS_HOURS_OFFSET', 0 ); 


### PR DESCRIPTION
Support multiple domains, simplify configuration & deployment
